### PR TITLE
Feat/make output more informative

### DIFF
--- a/node/lib/reporters/console.js
+++ b/node/lib/reporters/console.js
@@ -8,15 +8,21 @@ function printResults(logger, finding, config) {
     var printed = {};
     finding.results.forEach(function(elm) {
       var key = elm.component + ' ' + elm.version;
-      logFunc(finding.file);
-      logFunc(' ' + String.fromCharCode(8627) + ' ' + key);
       if (printed[key]) return;
       if (retire.isVulnerable([elm])) {
         logFunc(key + ' has known vulnerabilities:' + printVulnerability(logger, elm, config));
+        if (elm.parent) {
+          printParent(logFunc, elm, config);
+        }
       }
       printed[key] = true;
     });
   }
+}
+
+function printParent(logFunc, comp, options) {
+  if ('parent' in comp) printParent(logFunc, comp.parent, options);
+  logFunc(new Array(comp.level).join(' ') + (comp.parent ? String.fromCharCode(8627) + ' ' : '') + comp.component + ' ' + comp.version);
 }
 
 function printVulnerability(logger, component, config) {

--- a/node/lib/resolve.js
+++ b/node/lib/resolve.js
@@ -32,6 +32,10 @@ function listdep(parent, dep, level, deps) {
 			dedup[id] = true;
 			var d = {
 				module: { component: i, version: o.dep.dependencies[i].version }
+				component: i,
+				version: o.dep.dependencies[i].version,
+				parent: o.parent,
+				level: o.level,
 			};
 			if (o.dep.dependencies[i].path) {
 				d.file = "node_modules" + o.dep.dependencies[i].path.split("node_modules").slice(1).join("node_modules") + '/package.json'

--- a/node/lib/scanner.js
+++ b/node/lib/scanner.js
@@ -29,7 +29,7 @@ function emitResults(finding, options) {
 function shouldIgnorePath(fileSpecs, ignores) {
   return utils.detect(ignores.paths, function(i) {
     return utils.detect(fileSpecs, function(j) {
-      return j.indexOf(i) === 0 || j.indexOf(path.resolve(i)) === 0 ; 
+      return j.indexOf(i) === 0 || j.indexOf(path.resolve(i)) === 0 ;
     });
   });
 }
@@ -88,7 +88,7 @@ function scanDependencies(dependencies, nodeRepo, options) {
     if (options.ignore && shouldIgnorePath(fileSpecs, options.ignore)) {
       continue;
     }
-    results = retire.scanNodeDependency(dependencies[i].module, nodeRepo, options);
+    results = retire.scanNodeDependency(dependencies[i], nodeRepo, options);
     emitResults({file: dependencies[i].file, results: results}, options);
   }
 }
@@ -132,5 +132,3 @@ exports.scanBowerFile = function(file, repo, options) {
 exports.on = function(name, listener) {
   events.on(name, listener);
 };
-
-


### PR DESCRIPTION
https://github.com/RetireJS/retire.js/pull/232

**In retire.js 1.x the report had the following format:**

protobufjs 5.0.2 has known vulnerabilities: severity: medium; summary: Denial of Service; https://hackerone.com/reports/319576
node-site-venom 1.0.2843
↳ firebase 4.8.1
↳ @firebase/firestore 0.2.2
↳ grpc 1.8.0
↳ protobufjs 5.0.2

**Now we have this:**

node_modules/protobufjs/package.json
↳ protobufjs 5.0.2
protobufjs 5.0.2 has known vulnerabilities: severity: medium; summary: Denial of Service; https://hackerone.com/reports/319576

I've created the pr with changes for console reporter to have the first variant in report. It would be cool to have the previous version of report format. Because it's more informative for usage.